### PR TITLE
Enable debug true and diagnostics queries!

### DIFF
--- a/.github/codeql/DiagnosticNoExtractionErrors.ql
+++ b/.github/codeql/DiagnosticNoExtractionErrors.ql
@@ -1,0 +1,15 @@
+/**
+ * @name Diagnostic Successfully extracted files
+ * @kind diagnostic
+ * @id test/diagnostic/no-extraction-errors
+ */
+
+import csharp
+import semmle.code.csharp.commons.Diagnostics
+
+from File file
+where
+  file.fromSource() and
+  not exists(ExtractorError e | e.getLocation().getFile() = file) and
+  not exists(CompilerError e | e.getLocation().getFile() = file)
+select file, ""

--- a/.github/codeql/DiagnosticTest.ql
+++ b/.github/codeql/DiagnosticTest.ql
@@ -1,0 +1,7 @@
+/**
+ * @name Diagnostic Test
+ * @kind diagnostic
+ * @id test
+ */
+
+select "Test diagnostic message", 2

--- a/.github/codeql/FileDiagnostics.ql
+++ b/.github/codeql/FileDiagnostics.ql
@@ -1,9 +1,10 @@
 /**
  * @name File Diagnostics
  * @kind diagnostic
- * @id csharp/file-diagnostics
+ * @id test/diagnostic/file-diagnostics
  */
 
+import csharp
 
 select  "Count of files in the CodeQL Database: " + 
         ".csproj Files: '" + count(File f | f.getExtension() = "csproj" | f ) + "'," +

--- a/.github/codeql/FileDiagnostics.ql
+++ b/.github/codeql/FileDiagnostics.ql
@@ -1,0 +1,18 @@
+/**
+ * @name File Diagnostics
+ * @kind diagnostic
+ * @id csharp/file-diagnostics
+ */
+
+
+select  "Count of files in the CodeQL Database: " + 
+        ".csproj Files: '" + count(File f | f.getExtension() = "csproj" | f ) + "'," +
+        ".config Files: '" + count(File f | f.getExtension() = "config" | f ) + "'," +
+        ".xml Files: '" + count(File f | f.getExtension() = "xml" | f ) + "'," +
+        ".dll Files: '" + count(File f | f.getExtension() = "dll" | f ) + "'," +
+        ".asp Files: '" + count(File f | f.getExtension() = "asp" | f ) + "'," +
+        ".aspx Files: '" + count(File f | f.getExtension() = "aspx" | f ) + "'," +
+        ".ascx Files: '" + count(File f | f.getExtension() = "ascx" | f ) + "'," +
+        ".razor Files: '" + count(File f | f.getExtension() = "razor" | f ) + "'," +
+        ".cshtml Files: '" + count(File f | f.getExtension() = "cshtml" | f ) + "'," +
+        ".cs Files: '" + count(File f | f.getExtension() = "cs" | f ) + "'", 0

--- a/.github/codeql/qlpack.yml
+++ b/.github/codeql/qlpack.yml
@@ -1,0 +1,4 @@
+name: my-custom-queries
+version: 0.0.0
+libraryPathDependencies: codeql/csharp-all
+suites: my-custom-suites

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,7 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
         queries: security-and-quality
+        debug: true
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-        queries: security-and-quality, github/codeql/tree/main/csharp/ql/src/Diagnostics@main
+        queries: security-and-quality, github/codeql/csharp/ql/src/Diagnostics@main
         debug: true
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-        queries: security-and-quality, github/codeql/csharp/ql/src/Diagnostics@main
+        queries: security-and-quality, github/codeql/csharp/ql/src/Diagnostics/DiagnosticExtractionErrors.ql@main
         debug: true
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-        queries: security-and-quality
+        queries: security-and-quality, github/codeql/tree/main/csharp/ql/src/Diagnostics
         debug: true
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,8 @@ jobs:
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-        queries: github/codeql/csharp/ql/src/Diagnostics/DiagnosticExtractionErrors.ql@main
+        #queries: github/codeql/csharp/ql/src/Diagnostics/DiagnosticExtractionErrors.ql@main
+        queries: .github/codeql/DiagnosticTest.ql
         debug: true
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
         #queries: github/codeql/csharp/ql/src/Diagnostics/DiagnosticExtractionErrors.ql@main
-        queries: .github/codeql/DiagnosticTest.ql
+        queries: ./.github/codeql/DiagnosticTest.ql
         debug: true
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-        queries: security-and-quality, github/codeql/csharp/ql/src/Diagnostics/DiagnosticExtractionErrors.ql@main
+        queries: github/codeql/csharp/ql/src/Diagnostics/DiagnosticExtractionErrors.ql@main
         debug: true
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
         #queries: github/codeql/csharp/ql/src/Diagnostics/DiagnosticExtractionErrors.ql@main
-        queries: ./.github/codeql/DiagnosticTest.ql
+        queries: ./.github/codeql
         debug: true
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-        queries: security-and-quality, github/codeql/tree/main/csharp/ql/src/Diagnostics
+        queries: security-and-quality, github/codeql/tree/main/csharp/ql/src/Diagnostics@main
         debug: true
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).


### PR DESCRIPTION
NOTE: The workflow property "queries.uses" is invalid: must be a built-in suite (security-extended or security-and-quality), a relative path, or be of the form "owner/repo[/path]@ref"

# Diagnostics Query - returns 1 message and code (note,warning,error)

> |               Diagnostic                |      Summary       |
> +-----------------------------------------+--------------------+
> | Diagnostic Test                         | 1 result (1 error) |
> | File Diagnostics                        | 1 result (1 note)  |
> 
> Query 'Diagnostic Test' (test) produced the following diagnostic messages:
>   * Error: Test diagnostic message
> 
> Query 'File Diagnostics' (test/diagnostic/file-diagnostics) produced the following diagnostic messages:
>   * Note: Count of files in the CodeQL Database: .csproj Files: '1',.config Files: '2',.xml Files: '3',.dll Files: '16',.asp Files: '0',.aspx Files: '71',.ascx Files: '0',.razor Files: '0',.cshtml Files: '0',.cs Files: '156'
> 
> 
> 

# Try 1 - All diagnostics:
queries: security-and-quality, github/codeql/csharp/ql/src/Diagnostics@main

>  /opt/hostedtoolcache/CodeQL/0.0.0-20220811/x64/codeql/codeql resolve queries /home/runner/work/_temp/github/codeql/main/csharp/ql/src/Diagnostics --format=bylanguage --additional-packs /home/runner/work/_temp/github/codeql/main
  Recording pack reference codeql/csharp-queries at /home/runner/work/_temp/github/codeql/main/csharp/ql/src.
  {
    "byLanguage" : {
      "csharp" : {
        "/home/runner/work/_temp/github/codeql/main/csharp/ql/src/Diagnostics/CompilerError.ql" : { },
        "/home/runner/work/_temp/github/codeql/main/csharp/ql/src/Diagnostics/CompilerMessage.ql" : { },
        "/home/runner/work/_temp/github/codeql/main/csharp/ql/src/Diagnostics/DiagnosticExtractionErrors.ql" : { },
        "/home/runner/work/_temp/github/codeql/main/csharp/ql/src/Diagnostics/DiagnosticNoExtractionErrors.ql" : { },
        "/home/runner/work/_temp/github/codeql/main/csharp/ql/src/Diagnostics/ExtractorError.ql" : { },
        "/home/runner/work/_temp/github/codeql/main/csharp/ql/src/Diagnostics/ExtractorMessage.ql" : { }
      }
    },
    "noDeclaredLanguage" : { },
    "multipleDeclaredLanguages" : { }
  }

## Try 1 Result - stack overflow
>Checking QL for /home/runner/work/_temp/github/codeql/main/csharp/ql/src/Diagnostics/CompilerError.ql.
  Oops! A fatal internal error occurred.
  java.lang.StackOverflowError
  	at com.semmle.frontend.compiler.codegen.TypeCompiler.computeSize(TypeCompiler.java:398)